### PR TITLE
Mode definitions in Chef shouldn't be strings. 

### DIFF
--- a/Cookbook File/cookbook_file-full.sublime-snippet
+++ b/Cookbook File/cookbook_file-full.sublime-snippet
@@ -6,7 +6,7 @@ cookbook_file "${1:name}" do
 	source "${4:source}"
 	owner "${5:root}"
 	group "${6:root}"
-	mode "${7:0644}"
+	mode ${7:00644}
 	backup ${8:5}
 	cookbook "${9:cookbook}"
 end

--- a/Cookbook File/cookbook_file.sublime-snippet
+++ b/Cookbook File/cookbook_file.sublime-snippet
@@ -4,7 +4,7 @@ cookbook_file "${1:name}" do
 	source "${2:source}"
 	owner "root"
 	group "root"
-	mode "0644"
+	mode 00644
 end
 
 ]]></content>

--- a/Directory/directory-full.sublime-snippet
+++ b/Directory/directory-full.sublime-snippet
@@ -4,7 +4,7 @@ directory "${1:name}" do
 	action :${2:create}
 	owner "${3:root}"
 	group "${4:root}"
-	mode "${5:0755}"
+	mode ${5:00755}
 	path "${6:name}"
 	recursive ${7:false}
 end

--- a/Directory/directory-recursive.sublime-snippet
+++ b/Directory/directory-recursive.sublime-snippet
@@ -3,7 +3,7 @@
 directory "${1:name}" do
 	owner "root"
 	group "root"
-	mode "0755"
+	mode 00755
 	action :create
 	recursive true
 end

--- a/Directory/directory.sublime-snippet
+++ b/Directory/directory.sublime-snippet
@@ -3,7 +3,7 @@
 directory "${1:name}" do
 	owner "root"
 	group "root"
-	mode "0755"
+	mode 00755
 	action :create
 end
 

--- a/File/file-content.sublime-snippet
+++ b/File/file-content.sublime-snippet
@@ -4,7 +4,7 @@ file "${1:name}" do
 	action :create
 	owner "root"
 	group "root"
-	mode "0644"
+	mode 00644
 	content "${2:content here}"
 end
 

--- a/File/file-full.sublime-snippet
+++ b/File/file-full.sublime-snippet
@@ -6,7 +6,7 @@ file "${1:name}" do
 	backup ${4:5}
 	owner "${5:root}"
 	group "${6:root}"
-	mode "${7:0644}"
+	mode ${7:00644}
 	content "${8:content here}"
 end
 

--- a/File/file.sublime-snippet
+++ b/File/file.sublime-snippet
@@ -4,7 +4,7 @@ file "${1:name}" do
 	action :create
 	owner "root"
 	group "root"
-	mode "0644"
+	mode 00644
 end
 
 ]]></content>

--- a/Remote Directory/remote_directory-full.sublime-snippet
+++ b/Remote Directory/remote_directory-full.sublime-snippet
@@ -5,10 +5,10 @@ remote_directory "${1:/tmp/remote_something}" do
 	files_backup ${3:10}
 	files_owner "${4:root}"
 	files_group "${5:root}"
-	files_mode "${6:0644}"
+	files_mode ${6:00644}
 	owner "${7:root}"
 	group "${8:root}"
-	mode "${9:0755}"
+	mode ${9:00755}
 	cookbook ${10:nil}
 	purge ${11:false}
 	overwrite ${12:true}

--- a/Remote Directory/remote_directory.sublime-snippet
+++ b/Remote Directory/remote_directory.sublime-snippet
@@ -4,10 +4,10 @@ remote_directory "${1:/tmp/remote_something}" do
 	source "${2:something}"
 	files_owner "${3:root}"
 	files_group "${4:root}"
-	files_mode "${5:0644}"
+	files_mode ${5:00644}
 	owner "${6:root}"
 	group "${7:root}"
-	mode "${8:0755}"
+	mode ${8:00755}
 end
 
 ]]></content>

--- a/Remote File/remote_file.sublime-snippet
+++ b/Remote File/remote_file.sublime-snippet
@@ -3,7 +3,7 @@
 remote_file "${1:/tmp/remote_file}" do
   owner "${2:root}"
   group "${3:root}"
-  mode "${4:0644}"
+  mode ${4:00644}
   source "${5:http://www.example.com/remote_file}"
   checksum "${6:sha256checksum}"
 end

--- a/Remote File/remote_filef.sublime-snippet
+++ b/Remote File/remote_filef.sublime-snippet
@@ -5,7 +5,7 @@ remote_file "${1:/tmp/remote_file}" do
   backup ${3:5}
   owner "${4:root}"
   group "${5:root}"
-  mode "${6:0644}"
+  mode ${6:00644}
   source "${7:http://www.example.com/remote_file}"
   checksum "${8:sha256checksum}"
 end

--- a/Remote File/remote_filem.sublime-snippet
+++ b/Remote File/remote_filem.sublime-snippet
@@ -4,7 +4,7 @@ remote_file "${1:/tmp/remote_file}" do
   action ${2::create_if_missing}
   owner "${3:root}"
   group "${4:root}"
-  mode "${5:0644}"
+  mode ${5:00644}
   source "${6:http://www.example.com/remote_file}"
 end
 

--- a/Template/template-variables.sublime-snippet
+++ b/Template/template-variables.sublime-snippet
@@ -4,7 +4,7 @@ template "${1:name}" do
 	source "${2:source}.erb"
 	owner "root"
 	group "root"
-	mode "0644"
+	mode 00644
 	variables( ${3::config_var => node[:configs][:config_var]} )
 end
 

--- a/Template/template.sublime-snippet
+++ b/Template/template.sublime-snippet
@@ -4,7 +4,7 @@ template "${1:name}" do
 	source "${2:source}.erb"
 	owner "root"
 	group "root"
-	mode "0644"
+	mode 00644
 end
 
 ]]></content>


### PR DESCRIPTION
There's no need for this and it breaks Food Critic FC002.  I've turned
them into 5 digit values
