### PR TITLE
Update metadata to match current standards

### DIFF
--- a/Metadata/metadata.sublime-snippet
+++ b/Metadata/metadata.sublime-snippet
@@ -1,11 +1,12 @@
 <snippet>
   <content><![CDATA[
-maintainer       "${1:YOUR_COMPANY_NAME}"
-maintainer_email "${2:YOUR_EMAIL}"
-license          "${3:All rights reserved}"
-description      "${4:Installs/Configures example}"
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
-version          "${5:0.0.1}"
+name             "${1:example}"
+maintainer       "${2:YOUR_COMPANY_NAME}"
+maintainer_email "${3:YOUR_EMAIL}"
+license          "${4:All rights reserved}"
+description      "${5:Installs/Configures example}"
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          "${6:0.1.0}"
 
 ]]></content>
   <!-- Optional: Set a tabTrigger to define how to trigger the snippet -->

--- a/Metadata/metadataf.sublime-snippet
+++ b/Metadata/metadataf.sublime-snippet
@@ -5,8 +5,8 @@ maintainer       "YOUR_COMPANY_NAME"
 maintainer_email "YOUR_EMAIL"
 license          "All rights reserved"
 description      "Installs/Configures example"
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
-version          "0.0.1"
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          "0.1.0"
 depends          "package"
 attribute        "pets/cat/name",:display_name => "Cat Name"
 grouping         "pets/cat",:title => "Cat Options"


### PR DESCRIPTION
name attribute should always be includes, versions start at 0.1.0 not
0.0.1, and rdoc is no longer the preferred readme format
