### PR TITLE
Add export-ignore to non-package files per community standards

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,7 @@
 * text=auto eol=lf
+.github/ export-ignore
+.circleci/ export-ignore
+.mdlrc export-ignore
+.rubocop.yml export-ignore
+Dangerfile export-ignore
+*.sublime-project export-ignore


### PR DESCRIPTION
This is a requirement for submitting a package to PackageControl. See
https://raw.githubusercontent.com/wbond/package_control_channel/master/.github/PULL_REQUEST_TEMPLATE.md