### PR TITLE
[QuickFix] Remove rubocop.yml and autofix Dangerfile

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,0 @@
----
-AllCops:
-  Exclude:
-    - 'Dangerfile'

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Reference: http://danger.systems/reference.html
 
 # A pull request summary is required. Add a description of the pull request purpose.
@@ -10,7 +12,7 @@
 #    Pull requests with code changes without changelog entry
 
 def code_changes?
-  code = %w(libraries attributes recipes resources files templates)
+  code = %w[libraries attributes recipes resources files templates]
   code.each do |location|
     return true unless git.modified_files.grep(/#{location}/).empty?
   end
@@ -18,7 +20,7 @@ def code_changes?
 end
 
 def test_changes?
-  tests = %w(spec test .kitchen.yml .kitchen.dokken.yml)
+  tests = %w[spec test .kitchen.yml .kitchen.dokken.yml]
   tests.each do |location|
     return true unless git.modified_files.grep(/#{location}/).empty?
   end
@@ -30,11 +32,7 @@ failure 'Please provide a summary of your Pull Request.' if github.pr_body.lengt
 warn 'This is a big Pull Request.' if git.lines_of_code > 400
 
 # Require a CHANGELOG entry for non-test changes.
-if !git.modified_files.include?('CHANGELOG.md') && code_changes?
-  failure 'Please include a CHANGELOG entry.'
-end
+failure 'Please include a CHANGELOG entry.' if !git.modified_files.include?('CHANGELOG.md') && code_changes?
 
 # A sanity check for tests.
-if git.lines_of_code > 5 && code_changes? && !test_changes?
-  warn 'This Pull Request is probably missing tests.'
-end
+warn 'This Pull Request is probably missing tests.' if git.lines_of_code > 5 && code_changes? && !test_changes?


### PR DESCRIPTION
# Description

Cleans up dangerfile. No functional changes, just rubocop
This will not require a release or tag, it does not change the plugin

## Issues Resolved

#35

## CheckList

~~- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`~~
~~- [ ] New functionality includes testing.~~
~~- [ ] New functionality has been documented in the README if applicable.~~
